### PR TITLE
Add pending contact data for the email verification template

### DIFF
--- a/src/services/ContactsService.php
+++ b/src/services/ContactsService.php
@@ -177,6 +177,7 @@ class ContactsService extends Component
                     'message' => $bodyText,
                     'url' => $url,
                     'mailingList' => $mailingList,
+                    'pendingContact' => $pendingContact,
                 ]);
             }
             catch (\Twig_Error_Loader $e) {}

--- a/src/templates/settings/mailinglisttypes/_edit.html
+++ b/src/templates/settings/mailinglisttypes/_edit.html
@@ -72,7 +72,7 @@
 
         {{ forms.textField({
             label: "Verify Email Template"|t('campaign'),
-            instructions: "The template to use for the verification email that is sent to users (leave blank for default message template)."|t('campaign') ~ ' ' ~ macros.info(infoText, {tags: '`url`, `mailingList`'}),
+            instructions: "The template to use for the verification email that is sent to users (leave blank for default message template)."|t('campaign') ~ ' ' ~ macros.info(infoText, {tags: '`url`, `mailingList`, `pendingContact`'}),
             name: 'verifyEmailTemplate',
             value: mailingListType.verifyEmailTemplate,
             errors: mailingListType.getErrors('verifyEmailTemplate'),


### PR DESCRIPTION
This will allow emails to be personable by addressing user's by their first name or other field data.