### PR TITLE
Use Craft::info instead of Craft::warning in logUserAction

### DIFF
--- a/src/Campaign.php
+++ b/src/Campaign.php
@@ -315,7 +315,7 @@ class Campaign extends Plugin
 
         $params['username'] = Craft::$app->getUser()->getIdentity()->username;
 
-        Craft::warning(Craft::t('campaign', $message, $params), $category);
+        Craft::info(Craft::t('campaign', $message, $params), $category);
     }
 
     // Protected Methods


### PR DESCRIPTION
I've started using Sentry to get better insights into errors and warnings. And I get tons of warnings from Campaign.. It's just that these shouldn't really be warnings at all.. Wouldn't you agree? See this example:
https://sentry.dfo.no/share/issue/45e324b509ba4f0da02c43019e42af90/