### PR TITLE
Fix 404 error on tracker pixel

### DIFF
--- a/src/controllers/TrackerController.php
+++ b/src/controllers/TrackerController.php
@@ -68,11 +68,7 @@ class TrackerController extends Controller
 
         // Return tracking image
         $response = Craft::$app->getResponse();
-        $response->getHeaders()->set('Content-Type', 'image/gif');
-        $response->format = Response::FORMAT_RAW;
-        $response->stream = fopen(Craft::getAlias('@putyourlightson/campaign/resources/images/t.gif'), 'rb');
-
-        return $response->send();
+        return $response->sendFile(Craft::getAlias('@putyourlightson/campaign/resources/images/t.gif'));
     }
 
     /**


### PR DESCRIPTION
While combing through warnings and errors, I see that at least in my install, the `actions/campaign/t/open` action throws a 404.. If making the proposed changes, the error goes away for me, but maybe this requires some more testing?