### PR TITLE
Fix allow anonymous in webhook controller

### DIFF
--- a/src/controllers/WebhookController.php
+++ b/src/controllers/WebhookController.php
@@ -64,6 +64,8 @@ class WebhookController extends Controller
         if ($key === null || empty($apiKey) || $key != $apiKey) {
             throw new ForbiddenHttpException('Unauthorised access.');
         }
+
+        parent::init();
     }
 
     /**


### PR DESCRIPTION
This fix the allow anonymous feature by calling the parent::init() function needed to normalize the values of the $allowAnonymous variable.

Without this fix, it's impossible to run any actions in the webhook controller when your are not logged in Craft.

https://github.com/craftcms/cms/blob/ff1186c974652e47be5bad88b68168b99da73f1f/src/web/Controller.php#L73

