### PR TITLE
Fix error thrown when updating a contact from a queue job

### DIFF
--- a/src/helpers/ContactActivityHelper.php
+++ b/src/helpers/ContactActivityHelper.php
@@ -68,7 +68,12 @@ class ContactActivityHelper
 
         // Get device detector
         if (self::$_deviceDetector === null) {
-            $userAgent = Craft::$app->getRequest()->getUserAgent();
+            if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+                $userAgent = '';
+            } else {
+                $userAgent = Craft::$app->getRequest()->getUserAgent();
+            }
+            
             self::$_deviceDetector = new DeviceDetector($userAgent);
         }
 


### PR DESCRIPTION
Refer to the actual issue with Formie here = https://github.com/verbb/formie/issues/181 where it tries to subscribe users inside a queue job.

But this could be an issue if someone wanted to update contacts in their own queue jobs, outside of Formie. They'll get the following error, or similar.

```
> verbb\formie\errors\IntegrationException: API error: “Calling unknown method: craft\console\Request::getUserAgent()” /vendor/yiisoft/yii2/base/Component.php:300
```

Particularly if their queue processing is set to be from the CLI. Is their queue processing is being done automatically from CP requests `runQueueAutomatically => true`, then this won't be an issue. It's only an issue with `runQueueAutomatically = false` and running `./craft queue/listen` to process queue jobs.

Looking at https://github.com/matomo-org/device-detector/blob/master/DeviceDetector.php it seems valid to pass an empty string, or even null, so feel free to change what feels best for you code-wise.

Thoughts?