### PR TITLE
Allow importing relational field data by detecting and parsing arrays of IDs in CSV imports

### DIFF
--- a/src/services/ImportsService.php
+++ b/src/services/ImportsService.php
@@ -282,7 +282,12 @@ class ImportsService extends Component
 
             foreach ($import->fieldIndexes as $field => $index) {
                 if ($index !== '' && isset($row[$index])) {
-                    $values[$field] = $row[$index];
+                    $value = $row[$index];
+                    // Test if array of numbers
+                    if (preg_match('/^\[(?:\d,? ?)+]$/', $value)) {
+                        $arrayValue = json_decode($value);
+                    }
+                    $values[$field] = $arrayValue ?? $value;
                 }
             }
 


### PR DESCRIPTION
This enables importing relations from CSV data. If the importer finds a value that looks like an array of IDs (one or more numbers inside square brackets, separated by commas and optional spaces), the value gets parsed into a real array and saved into the element's field. I've quickly patched this in in order to be able to import lists of categories into my contacts.

CSVs like this should now work for importing relations to existing categories, entries, assets (or any other element) by ID:

| email | first_name | last_name | genres
| --- | --- | --- | --- |
| abc@example.com | Peter | Piper | `[412,554,199,412]` | 
| def@example.com | Sue | Swiper | `[9512]` |
| ghi@example.com | Clark | Coolidge | `[12,41]` |


