### PR TITLE
Fixes return type for `encodeEmojis`

### DIFF
--- a/src/helpers/SendoutHelper.php
+++ b/src/helpers/SendoutHelper.php
@@ -35,7 +35,7 @@ class SendoutHelper
      *
      * @since 2.9.2
      */
-    public static function encodeEmojis(?string $value): string
+    public static function encodeEmojis(?string $value): ?string
     {
         if (!Craft::$app->getDb()->getIsMysql()) {
             return $value;


### PR DESCRIPTION
Currently, this seems to be preventing creating new, empty sendouts using the New Sendout button.

```
[web.ERROR] [TypeError] putyourlightson\campaign\helpers\SendoutHelper::encodeEmojis(): Return value must be of type string, null returned
```