### PR TITLE
Updates contacts query for large lists

### DIFF
--- a/src/elements/SendoutElement.php
+++ b/src/elements/SendoutElement.php
@@ -1040,7 +1040,11 @@ class SendoutElement extends Element
      */
     public function getPendingRecipientCount(): int
     {
-        return count($this->getPendingRecipients());
+        if ($this->_pendingRecipients !== null) {
+            return count($this->_pendingRecipients);
+        }
+
+        return Campaign::$plugin->sendouts->getPendingRecipientCount($this);
     }
 
     /**

--- a/src/elements/SendoutElement.php
+++ b/src/elements/SendoutElement.php
@@ -1040,11 +1040,7 @@ class SendoutElement extends Element
      */
     public function getPendingRecipientCount(): int
     {
-        if ($this->_pendingRecipients !== null) {
-            return count($this->_pendingRecipients);
-        }
-
-        return Campaign::$plugin->sendouts->getPendingRecipientCount($this);
+        return count($this->getPendingRecipients());
     }
 
     /**


### PR DESCRIPTION
This Pull Request:

1. Adds faster calculation of expected recipients for regular sendouts 11cfb80c9d82311364ceb9c766f444259e136395<br/>
  Now, the existing contact IDs are used to calculate the count. I did not implement that for other sendout types yet, but it falls back to the original approach. Without this change, I found the “expected recipients” spinner and sendouts element index could hang.<br/><br/>
2. Adds batch query when querying regular sendout recipients db8791288a2c7069b46c0055f0ab539358b3e3b7<br/>
  Admittedly not my area of expertise, but as I understand it, [this is the way to deal with the potential size of that query?](https://www.yiiframework.com/doc/guide/2.0/en/db-active-record#data-in-batches) It does seem to be working now.

Thanks very much!