### PR TITLE
Add success message to JSON response

### DIFF
--- a/src/controllers/FormsController.php
+++ b/src/controllers/FormsController.php
@@ -46,8 +46,10 @@ class FormsController extends BaseMessageController
             return $this->asModelFailure($contact, Craft::t('campaign', 'Couldn’t save contact.'), $modelName);
         }
 
+        $message = $mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Thank you for subscribing to the mailing list. Please check your email for a verification link.') : Craft::t('campaign', 'You have successfully subscribed to the mailing list.');
+        
         if ($this->request->getAcceptsJson()) {
-            return $this->asSuccess($mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Thank you for subscribing to the mailing list. Please check your email for a verification link.') : Craft::t('campaign', 'You have successfully subscribed to the mailing list.'),);
+            return $message;
         }
 
         if ($this->request->getBodyParam('redirect')) {
@@ -56,7 +58,7 @@ class FormsController extends BaseMessageController
 
         return $this->renderMessageTemplate($mailingList->getMailingListType()->subscribeSuccessTemplate, [
             'title' => $mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Subscribed') : Craft::t('campaign', 'Subscribe'),
-            'message' => $mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Thank you for subscribing to the mailing list. Please check your email for a verification link.') : Craft::t('campaign', 'You have successfully subscribed to the mailing list.'),
+            'message' => $message,
             'mailingList' => $mailingList,
         ]);
     }

--- a/src/controllers/FormsController.php
+++ b/src/controllers/FormsController.php
@@ -47,7 +47,7 @@ class FormsController extends BaseMessageController
         }
 
         if ($this->request->getAcceptsJson()) {
-            return $this->asSuccess();
+            return $this->asSuccess($mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Thank you for subscribing to the mailing list. Please check your email for a verification link.') : Craft::t('campaign', 'You have successfully subscribed to the mailing list.'),);
         }
 
         if ($this->request->getBodyParam('redirect')) {

--- a/src/controllers/FormsController.php
+++ b/src/controllers/FormsController.php
@@ -49,7 +49,7 @@ class FormsController extends BaseMessageController
         $message = $mailingList->mailingListType->subscribeVerificationRequired ? Craft::t('campaign', 'Thank you for subscribing to the mailing list. Please check your email for a verification link.') : Craft::t('campaign', 'You have successfully subscribed to the mailing list.');
         
         if ($this->request->getAcceptsJson()) {
-            return $message;
+            return $this->asSuccess($message);
         }
 
         if ($this->request->getBodyParam('redirect')) {


### PR DESCRIPTION
Right now, the subscribe response is empty on success. This adds the same message as when using a normal form.