### PR TITLE
Change |ucfirst to |capitalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Campaign
 
+## 2.17.12 - Unreleased
+
+### Changed
+
+- Changed the use of the deprecated `|ucfirst` filter to `|capitalize` in all Twig templates.
+
 ## 2.17.11 - 2025-04-01
 
 ### Fixed
@@ -128,8 +134,8 @@
 
 ### Fixed
 
-- Fixed a bug in which the total recipient count in running sendouts was being incorrectly displayed. 
-- Fixed a typo in the `All` interaction type in English. 
+- Fixed a bug in which the total recipient count in running sendouts was being incorrectly displayed.
+- Fixed a typo in the `All` interaction type in English.
 
 ## 2.13.2 - 2024-04-01
 
@@ -152,7 +158,7 @@
 - Added batching to sync queue jobs.
 
 ### Changed
- 
+
 - Campaign now requires Craft CMS 4.4.0 or later.
 - The sendout job batch size is now set to `100` by default, unless it was previously modified by the `maxBatchSize` config setting.
 - The sendout job batch delay is now set to `0` by default, unless it was previously modified by the `batchJobDelay` config setting.
@@ -179,7 +185,7 @@
 ## 2.12.2 - 2024-03-05
 
 ### Changed
- 
+
 - A custom log target is now only registered if a dispatcher exists.
 
 ### Security

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "putyourlightson/craft-campaign",
   "description": "Send and manage email campaigns, contacts and mailing lists.",
-  "version": "2.17.11",
+  "version": "2.17.12",
   "type": "craft-plugin",
   "homepage": "https://putyourlightson.com/plugins/campaign",
   "license": "proprietary",

--- a/src/templates/_includes/contact-mailing-list-subscribe-row.twig
+++ b/src/templates/_includes/contact-mailing-list-subscribe-row.twig
@@ -11,7 +11,7 @@
     </th>
     <td>
         <label class="subscriptionStatus {{ subscriptionStatus ?: 'none' }}">
-            {{ subscriptionStatus ? subscriptionStatus|ucfirst|t('campaign') : 'None'|t('campaign') }}
+            {{ subscriptionStatus ? subscriptionStatus|capitalize|t('campaign') : 'None'|t('campaign') }}
         </label>
     </td>
     <td class="thin">

--- a/src/templates/reports/_includes/devices.twig
+++ b/src/templates/reports/_includes/devices.twig
@@ -11,7 +11,7 @@
         <tbody>
             {% for device in devices %}
                 <tr>
-                    <td data-title="{{ 'Device'|t('campaign') }}"><span class="device {{ device.device }}"></span> {{ device.device ? device.device|ucfirst|t('campaign') : 'Unknown'|t('campaign') }}</td>
+                    <td data-title="{{ 'Device'|t('campaign') }}"><span class="device {{ device.device }}"></span> {{ device.device ? device.device|capitalize|t('campaign') : 'Unknown'|t('campaign') }}</td>
                     {% if reportUrl is not defined %}
                         <td data-title="{{ 'OS'|t('campaign') }}">{{ device.os and device.os != 'UNK' ? device.os|t('campaign') : 'Unknown'|t('campaign') }}</td>
                         <td data-title="{{ 'Client'|t('campaign') }}">{{ device.client and device.client != 'UNK' ? device.client|t('campaign') : 'Unknown'|t('campaign') }}</td>

--- a/src/templates/reports/campaigns/_includes/contact-activity.twig
+++ b/src/templates/reports/campaigns/_includes/contact-activity.twig
@@ -42,7 +42,7 @@
                             {% endif %}
                         </th>
                         <td data-title="{{ 'Interaction'|t('campaign') }}">
-                            {{ activity.interaction|ucfirst|t('campaign') }}
+                            {{ activity.interaction|capitalize|t('campaign') }}
                             {% if activity.links|length %}
                                 {% set info %}
                                     <p>

--- a/src/templates/reports/campaigns/_includes/report.twig
+++ b/src/templates/reports/campaigns/_includes/report.twig
@@ -168,7 +168,7 @@
                 {% for sendout in data.sendouts %}
                     <tr>
                         <th scope="row" data-title="{{ 'Title'|t('app') }}"><a href="{{ sendout.cpEditUrl }}">{{ sendout.title }}</a></th>
-                        <td data-title="{{ 'Sendout Type'|t('campaign') }}">{{ sendout.sendoutType|ucfirst }}</td>
+                        <td data-title="{{ 'Sendout Type'|t('campaign') }}">{{ sendout.sendoutType|capitalize }}</td>
                         <td data-title="{{ 'Recipients'|t('campaign') }}">{{ sendout.recipients }}</td>
                         <td data-title="{{ 'Send Date'|t('campaign') }}">{{ sendout.sendDate ? sendout.sendDate|datetime }}</td>
                         <td data-title="{{ 'Last Sent'|t('campaign') }}">{{ sendout.lastSent ? sendout.lastSent|datetime }}</td>

--- a/src/templates/reports/contacts/_includes/campaign-activity.twig
+++ b/src/templates/reports/contacts/_includes/campaign-activity.twig
@@ -18,7 +18,7 @@
                         {% endif %}
                     </th>
                     <td data-title="{{ 'Interaction'|t('campaign') }}">
-                        {{ activity.interaction|ucfirst|t('campaign') }}
+                        {{ activity.interaction|capitalize|t('campaign') }}
                         {% if activity.links|length %}
                             <span class="info">
                                 <p>

--- a/src/templates/reports/contacts/_includes/mailinglist-activity.twig
+++ b/src/templates/reports/contacts/_includes/mailinglist-activity.twig
@@ -17,13 +17,13 @@
                             <span class="line-through">{{ model.mailingListTitle }}</span>
                         {% endif %}
                     </th>
-                    <td data-title="{{ 'Interaction'|t('campaign') }}">{{ activity.interaction|ucfirst|t('campaign') }}</td>
+                    <td data-title="{{ 'Interaction'|t('campaign') }}">{{ activity.interaction|capitalize|t('campaign') }}</td>
                     <td data-title="{{ 'Source'|t('campaign') }}">
                         {% if model.sourceType %}
                             {% if activity.sourceUrl %}
-                                <a href="{{ activity.sourceUrl }}" class="go" target="_blank" rel="noopener">{{ model.sourceType|ucfirst|t('campaign') }}</a>
+                                <a href="{{ activity.sourceUrl }}" class="go" target="_blank" rel="noopener">{{ model.sourceType|capitalize|t('campaign') }}</a>
                             {% else %}
-                                {{ model.sourceType|ucfirst|t('campaign') }}
+                                {{ model.sourceType|capitalize|t('campaign') }}
                             {% endif %}
                         {% endif %}
                     </td>

--- a/src/templates/reports/contacts/_includes/report.twig
+++ b/src/templates/reports/contacts/_includes/report.twig
@@ -30,7 +30,7 @@
         </tr>
         <tr>
             <th class="light">{{ "Device"|t('campaign') }}</th>
-            <td><span class="device {{ contact.device }}"></span> {{ contact.device ? contact.device|ucfirst|t('campaign') }}</td>
+            <td><span class="device {{ contact.device }}"></span> {{ contact.device ? contact.device|capitalize|t('campaign') }}</td>
         </tr>
         <tr>
             <th class="light">{{ "OS"|t('campaign') }}</th>

--- a/src/templates/reports/mailinglists/_includes/contact-activity.twig
+++ b/src/templates/reports/mailinglists/_includes/contact-activity.twig
@@ -19,11 +19,11 @@
                             {% endif %}
                         </th>
                         <td data-title="{{ 'Interaction'|t('campaign') }}">
-                            {{ activity.interaction|ucfirst|t('campaign') }}
+                            {{ activity.interaction|capitalize|t('campaign') }}
                         </td>
                         <td data-title="{{ 'Source'|t('campaign') }}">
                             {% if model.sourceType %}
-                                <a href="{{ activity.sourceUrl }}" class="go" target="_blank" rel="noopener">{{ model.sourceType|ucfirst|t('campaign') }}</a>
+                                <a href="{{ activity.sourceUrl }}" class="go" target="_blank" rel="noopener">{{ model.sourceType|capitalize|t('campaign') }}</a>
                             {% endif %}
                         </td>
                         <td data-order="{{ activity.date|datetime('U') }}" data-title="{{ 'First Interaction'|t('campaign') }}">{{ activity.date|datetime }}</td>

--- a/src/templates/reports/mailinglists/_includes/report.twig
+++ b/src/templates/reports/mailinglists/_includes/report.twig
@@ -97,7 +97,7 @@
                 {% for sendout in data.sendouts %}
                     <tr>
                         <th scope="row" data-title="{{ 'Title'|t('app') }}"><a href="{{ sendout.cpEditUrl }}">{{ sendout.title }}</a></th>
-                        <td data-title="{{ 'Sendout Type'|t('campaign') }}">{{ sendout.sendoutType|ucfirst }}</td>
+                        <td data-title="{{ 'Sendout Type'|t('campaign') }}">{{ sendout.sendoutType|capitalize }}</td>
                         <td data-title="{{ 'Recipients'|t('campaign') }}">{{ sendout.recipients }}</td>
                         <td data-title="{{ 'Send Date'|t('campaign') }}">{{ sendout.sendDate ? sendout.sendDate|datetime }}</td>
                         <td data-title="{{ 'Last Sent'|t('campaign') }}">{{ sendout.lastSent ? sendout.lastSent|datetime }}</td>


### PR DESCRIPTION
Fixes the depreciation error in Craft 4 and Campaign 2.x

> The `|ucfirst` filter has been deprecated. Use `|capitalize` instead.