### PR TITLE
Also save failed send attempts

### DIFF
--- a/src/services/SendoutsService.php
+++ b/src/services/SendoutsService.php
@@ -356,6 +356,10 @@ class SendoutsService extends Component
                 $sendout->sendStatus = SendoutElement::STATUS_FAILED;
             }
 
+            // Save failed record
+            $contactCampaignRecord->sent = null;
+            $contactCampaignRecord->save();
+
             $this->updateSendoutRecord($sendout, ['failures', 'sendStatus']);
 
             Campaign::$plugin->log('Sending of the sendout “{title}” to {email} failed after {sendAttempts} send attempt(s). Please check that your Campaign email settings are correctly configured and check the error in the Craft log.', [
@@ -570,8 +574,7 @@ class SendoutsService extends Component
     {
         $query = ContactCampaignRecord::find()
             ->select(['contactId'])
-            ->where(['sendoutId' => $sendout->id])
-            ->andWhere(['not', ['sent' => null]]);
+            ->where(['sendoutId' => $sendout->id]);
 
         if ($todayOnly) {
             $now = new DateTime();


### PR DESCRIPTION
Fixes https://github.com/putyourlightson/craft-campaign/issues/533

The issue was that when sending to a contact failed, that contact would appear first in the next batch. Over time, this caused failed contacts to accumulate at the start of each subsequent batch. Since these failed contacts were repeatedly processed and counted, the final batch(es) would eventually stop including newer contacts altogether.

The issue can be reproduced by setting `sendoutJobBatchSize` to `1` and sending a campaign to a list with two contacts, where the contact with the lowest ID fails (or by forcing `$success = false`). In this scenario, batch 2 (the final batch) will again include the same failed contact.

I’ve updated the logic so that failed attempts for a contact are now also saved and included as `SentRecipients`. However, I’m not entirely sure if the latter change affects other functionality — would appreciate it if you could review that part. Thanks!