### PR TITLE
Add webhook for Lettermint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Campaign
 
+## unreleased
+
+- Added a webhook controller action for [Lettermint](https://lettermint.co/).
+
 ## 3.8.1 - 2025-12-23
 
 - Fixed a bug in which campaigns could not be closed ([#539](https://github.com/putyourlightson/craft-campaign/issues/539)).

--- a/src/controllers/WebhookController.php
+++ b/src/controllers/WebhookController.php
@@ -40,6 +40,7 @@ class WebhookController extends Controller
         'test',
         'amazon-ses',
         'elastic-email',
+        'lettermint',
         'mailersend',
         'mailgun',
         'mandrill',
@@ -146,6 +147,38 @@ class WebhookController extends Controller
         }
         if ($status === 'AbuseReport') {
             return $this->callWebhook('complained', $email);
+        }
+
+        return $this->asRawSuccess();
+    }
+
+    /**
+     * Lettermint
+     * https://docs.lettermint.co/platform/webhooks/introduction
+     *
+     * @since 3.9.0
+     */
+    public function actionLettermint(): ?Response
+    {
+        $this->requirePostRequest();
+
+        $event = $this->request->getHeaders()->get('X-Lettermint-Event');
+        $data = $this->request->getBodyParam('data');
+
+        if (!$this->isValidLettermintRequest()) {
+            return $this->asRawFailure('Signature could not be authenticated.');
+        }
+
+        if ($event === 'webhook.test') {
+            return $this->asRawSuccess('Test success.');
+        }
+
+        if ($event === 'message.hard_bounced') {
+            return $this->callWebhook('bounced', $data['recipient']);
+        }
+
+        if ($event === 'message.spam_complaint') {
+            return $this->callWebhook('complained', $data['recipient']);
         }
 
         return $this->asRawSuccess();
@@ -420,6 +453,27 @@ class WebhookController extends Controller
         }
 
         return true;
+    }
+
+    /**
+     * @link https://docs.lettermint.co/platform/webhooks/signing
+     */
+    private function isValidLettermintRequest(): bool
+    {
+        if (!Campaign::$plugin->settings->validateWebhookRequests) {
+            return true;
+        }
+
+        $header = $this->request->headers->get('X-Lettermint-Signature', '');
+
+        if (!preg_match('/t=(\d+),v1=([a-f0-9]+)/', $header, $matches)) {
+            return false;
+        }
+
+        $signingKey = Campaign::$plugin->settings->getLettermintWebhookSigningSecret();
+        $hashedValue = hash_hmac('sha256', $matches[1] . $this->request->getRawBody(), $signingKey);
+
+        return hash_equals($matches[2], $hashedValue);
     }
 
     /**

--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -56,6 +56,12 @@ class SettingsModel extends Model
     public bool $validateWebhookRequests = false;
 
     /**
+     * @var string|null A webhook signing secret provided by Lettermint to validate incoming webhook requests
+     * @since 3.9.0
+     */
+    public ?string $lettermintWebhookSigningSecret = null;
+
+    /**
      * @var string|null A webhook signing secret provided by MailerSend to validate incoming webhook requests
      * @since 2.10.0
      */
@@ -328,6 +334,16 @@ class SettingsModel extends Model
     public function getApiKey(): string
     {
         return App::parseEnv($this->apiKey) ?? '';
+    }
+
+    /**
+     * Returns the parsed Lettermint webhook signing secret.
+     *
+     * @since 3.9.0
+     */
+    public function getLettermintWebhookSigningSecret(): string
+    {
+        return App::parseEnv($this->lettermintWebhookSigningSecret) ?? '';
     }
 
     /**

--- a/src/templates/_settings/general/index.twig
+++ b/src/templates/_settings/general/index.twig
@@ -83,6 +83,12 @@
                     </td>
                 </tr>
                 <tr>
+                    <th class="thin">Lettermint</th>
+                    <td class="textual code">
+                        <textarea rows="1" disabled>{{ siteUrl(craft.app.config.general.actionTrigger ~ '/campaign/webhook/lettermint', { key: apiKey }) }}</textarea>
+                    </td>
+                </tr>
+                <tr>
                     <th class="thin">
                         MailerSend
                     </th>

--- a/tests/Interface/WebhookTest.php
+++ b/tests/Interface/WebhookTest.php
@@ -187,6 +187,51 @@ test('An unsigned SendGrid request returns an error', function() {
         ->toBe(400);
 });
 
+test('A signed Lettermint bounce request marks the contact as bounced and returns a success', function() {
+    $contact = createContact();
+    $signingSecret = 'aBcDeFgHiJkLmNoP123';
+    Campaign::$plugin->settings->lettermintWebhookSigningSecret = $signingSecret;
+
+    $body = json_encode(getLettermintRequestBody($contact->email));
+    Craft::$app->request->setRawBody($body);
+
+    $timestamp = time();
+    $signature = hash_hmac('sha256', $timestamp . $body, $signingSecret);
+
+    Craft::$app->request->headers->set(
+        'X-Lettermint-Signature',
+        't=' . $timestamp . ',v1=' . $signature
+    );
+    Craft::$app->request->headers->set('X-Lettermint-Event', 'message.hard_bounced');
+
+    $response = runActionWithParams('webhook/lettermint', [
+        'key' => Campaign::$plugin->settings->apiKey,
+    ]);
+
+    $contact = ContactElement::findOne($contact->id);
+
+    expect($response->statusCode)
+        ->toBe(200)
+        ->and($contact->getStatus())
+        ->toBe(ContactElement::STATUS_BOUNCED);
+});
+
+test('An unsigned Lettermint request returns an error', function() {
+    $contact = createContact();
+    Campaign::$plugin->settings->lettermintWebhookSigningSecret = 'aBcDeFgHiJkLmNoP123';
+
+    $body = json_encode(getLettermintRequestBody($contact->email));
+    Craft::$app->request->setRawBody($body);
+    Craft::$app->request->headers->set('X-Lettermint-Event', 'message.hard_bounced');
+
+    $response = runActionWithParams('webhook/lettermint', [
+        'key' => Campaign::$plugin->settings->apiKey,
+    ]);
+
+    expect($response->statusCode)
+        ->toBe(400);
+});
+
 function runActionWithParams(string $action, array $params = []): Response
 {
     Craft::$app->request->setBodyParams($params);
@@ -243,6 +288,15 @@ function getSendgridRequestBody(string $email): array
         [
             'event' => 'bounce',
             'email' => $email,
+        ],
+    ];
+}
+
+function getLettermintRequestBody(string $email): array
+{
+    return [
+        'data' => [
+            'recipient' => $email,
         ],
     ];
 }


### PR DESCRIPTION
This PR adds a webhook integration for [Lettermint](https://lettermint.co/), a transactional email provider. A [mailer adapter](https://plugins.craftcms.com/lettermint) for Craft CMS is already available in the plugin store.

- webhook endpoint at `/actions/campaign/webhook/lettermint` that handles Lettermint events
- Supports hard bounces and spam complaints - marks contacts accordingly
- Webhook signature validation using HMAC SHA-256 (follows their [signing docs](https://docs.lettermint.co/platform/webhooks/signing))
- New `lettermintWebhookSigningSecret` setting for the signing secret (supports environment variables)
- Webhook URL now shows up in the settings page
- Includes tests for both signed and unsigned requests

The webhook listens for these events:
- `webhook.test`
- `message.hard_bounced`
- `message.spam_complaint`

Signature validation is optional (controlled by the existing `validateWebhookRequests` setting) and uses the same security approach as the other webhook integrations.