### PR TITLE
Fix double counting of failed send attempts causing premature batch termination in SendoutsJob

### DIFF
--- a/src/services/SendoutsService.php
+++ b/src/services/SendoutsService.php
@@ -121,14 +121,12 @@ class SendoutsService extends Component
     public function getPendingRecipientCount(SendoutElement $sendout): int
     {
         if ($sendout->sendoutType === 'regular' || $sendout->sendoutType === 'scheduled') {
-            $count = ContactElement::find()
+            return ContactElement::find()
                 ->id($this->getPendingRecipientsStandardIds($sendout))
                 ->count();
-        } else {
-            $count = count($this->getPendingRecipients($sendout));
         }
 
-        return $count - $sendout->failures;
+        return count($this->getPendingRecipients($sendout));
     }
 
     /**


### PR DESCRIPTION
### Summary

Failed send attempts are now stored in `campaign_contacts_campaigns`, but they are currently being counted twice when determining pending recipients.

This happens in two places:
- `SendoutsService::getPendingRecipientsStandardIds()` already excludes recipients that have been “sent” — which now also includes failed attempts.
- Failed attempts are then subtracted again separately.

### Problem

Because failures are double-counted, the number of pending recipients becomes artificially low when failures occur.

This leads to issues in the sendout batching process:
- `SendoutJob` relies on `BaseBatchedJob`, which continues spawning jobs while `offset < totalItems`.
- `totalItems` is based on the pending recipients count.
- Due to the incorrect (too low) count, batching stops prematurely.

As a result, not all recipients are processed.

This issue affects both v2 and v3.

### Steps to Reproduce

1. Set `sendoutJobBatchSize` to `1` in the config.
2. Force failures by modifying:
   `vendor/putyourlightson/craft-campaign/src/services/SendoutsService.php:339` to be `false`.
3. Create a sendout with a mailing list containing at least 3 recipients.
4. Run the sendout.

### Expected Result

All 3 recipients are processed.

### Actual Result

Only 2 recipients are processed due to premature termination of batching.